### PR TITLE
Allows for newer version of nokogiri. All tests pass.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,16 @@
 PATH
   remote: .
   specs:
-    ipstack (0.0.1)
-      nokogiri (~> 1.8.0)
+    ipstack (0.1.1)
+      nokogiri (>= 1.8, < 2.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    coderay (1.1.2)
     diff-lcs (1.3)
-    method_source (0.9.0)
-    mini_portile2 (2.3.0)
-    nokogiri (1.8.2)
-      mini_portile2 (~> 2.3.0)
-    pry (0.11.3)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
+    mini_portile2 (2.4.0)
+    nokogiri (1.10.1)
+      mini_portile2 (~> 2.4.0)
     rake (12.3.1)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
@@ -37,9 +32,8 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.16)
   ipstack!
-  pry
   rake (~> 12.3)
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.16.1
+   1.16.6

--- a/ipstack.gemspec
+++ b/ipstack.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_runtime_dependency 'nokogiri', '~> 1.8.0' # Ability to parse XML response
+  spec.add_runtime_dependency 'nokogiri', '>= 1.8', '< 2.0' # Ability to parse XML response
 
 
 end


### PR DESCRIPTION
Tested against nokogiri 1.10.1.